### PR TITLE
Get rid of the "Wide character in print at..." error

### DIFF
--- a/render.pl
+++ b/render.pl
@@ -63,7 +63,6 @@ my %vars = (
     courses_json => decode_utf8 encode_json(\%courses),
 );
 
-$template->process('index.html.tt', \%vars, 'index.html')
+$template->process('index.html.tt', \%vars, 'index.html', { binmode => ':utf8' })
     or die $template->error;
 
-say $template;


### PR DESCRIPTION
Hi,
Trying to run render.pl I always got a 
Wide character in print at /usr/lib... Template.pm line 201.
Fixed this with a binmode => ':utf8' in the template toolkit call.

ANother change is to remove the say $template because it just prints the address without any information