### PR TITLE
Update course list, GCT 217.43

### DIFF
--- a/announcement.md
+++ b/announcement.md
@@ -90,6 +90,7 @@ and data contributions from
 * Dotsent
 * duelafn
 * Azure-Wolf
+* MrAtoka
 
 ... and possibly others whose contributions I forgot to track. My apologies.
 

--- a/data/Advanced Combat.yaml
+++ b/data/Advanced Combat.yaml
@@ -1,5 +1,6 @@
 ---
 - availability:
+  - HS
   - NL
   - Syr
   cost: 2800
@@ -10,6 +11,7 @@
   time: 700
   title: Agile Combat 1
 - availability:
+  - HS
   - NL
   - Syr
   cost: 8400
@@ -55,6 +57,7 @@
   time: 3500
 
 - availability:
+  - HS
   - SoB
   cost: 16800
   description: Master the use of knives for maximum damage
@@ -64,6 +67,7 @@
   time: 2100
   title: Assassin, Knife Master
 - availability:
+  - HS
   - SoB
   cost: 16800
   description: Master the use of rifles for maximum damage
@@ -73,6 +77,7 @@
   time: 2100
   title: Assault, Rifle Master
 - availability:
+  - HS
   - SoB
   cost: 16800
   description: Master the use of clubs for maximum damage
@@ -82,6 +87,7 @@
   time: 2100
   title: Club Master
 - availability:
+  - HS
   - SoB
   cost: 16800
   description: Master the use of short barrel rifles for maximum damage
@@ -91,6 +97,7 @@
   time: 2100
   title: Enforcer, Short-barrel Master
 - availability:
+  - HS
   - SoB
   cost: 16800
   description: Master the use of hand guns for maximum damage
@@ -100,6 +107,7 @@
   time: 2100
   title: Intimidator, handgun Master
 - availability:
+  - HS
   - SoB
   cost: 16800
   description: Master the use of shotguns for maximum damage
@@ -109,6 +117,7 @@
   time: 2100
   title: Regulator, shotgun Master
 - availability:
+  - HS
   - SoB
   cost: 16800
   description: Master the use of sniper rifles for maximum damage

--- a/data/Advanced Ship Engineering.yaml
+++ b/data/Advanced Ship Engineering.yaml
@@ -11,6 +11,8 @@
   time: 700
   title: Basic Navigation Systems
 - availability:
+  - CVS
+  - HS
   - Tau
   - Syr
   cost: 7000
@@ -34,6 +36,7 @@
   title: Master Ship Engineer
 - availability:
     - CVS
+    - HS
     - Moi
     - Syr
   cost: 5600
@@ -45,6 +48,7 @@
   title: Basic Ship Engines
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 5600
   description: Repair your hull slightly faster.
@@ -55,6 +59,7 @@
   title: Basic Ship Hull Maintenance
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 5600
   description: Repair your life support slightly faster.
@@ -77,6 +82,7 @@
     - CVS
     - Tau
     - Syr
+    - HS
   cost: 14000
   description: Repair your navigation computers faster.
   level: 5
@@ -88,6 +94,7 @@
   - Tau
   - CVS
   - Syr
+  - HS
   cost: 14000
   description: Repair your engines faster
   level: 5
@@ -97,6 +104,7 @@
   time: 1400
 - availability:
   - CVS
+  - HS
   - Syr
   cost: 14000
   description: Repair your hull faster
@@ -107,6 +115,7 @@
   time: 1400
 - availability:
   - CVS
+  - HS
   - Syr
   cost: 14000
   description: Repair your life support faster
@@ -119,6 +128,7 @@
     - SoB
     - CVS
     - Syr
+    - HS
   cost: 25200
   description: Repair your navigation computers much faster
   level: 6
@@ -130,6 +140,7 @@
     - SoB
     - CVS
     - Syr
+    - HS
   cost: 25200
   description: Repair your engines much faster
   level: 6
@@ -139,6 +150,7 @@
   title: Ship Engines Master
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 25200
   description: Repair your hull much faster
@@ -149,6 +161,7 @@
   title: Ship Hull Maintenance Master
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 25200
   description: Repair your life support much faster

--- a/data/Ship Engineering.yaml
+++ b/data/Ship Engineering.yaml
@@ -12,6 +12,7 @@
   time: 700
   title: Introduction to Ship Engineering
 - availability:
+  - HS
   - NL
   cost: 5600
   description: Slightly reduce the fuel consumption of your ship.
@@ -31,6 +32,7 @@
   time: 700
   title: Basic Ship Maintenance
 - availability:
+  - HS
   - Moi
   cost: 14000
   description: Reduce the fuel consumption of your ship
@@ -50,6 +52,7 @@
   time: 1400
   title: Advanced Ship Maintenance
 - availability:
+  - HS
   - Tau
   cost: 25200
   description: Greatly reduce the fuel consumption of your ship.
@@ -60,6 +63,7 @@
   time: 2100
   title: Fuel Efficiency Master
 - availability:
+  - HS
   - NL
   cost: 25200
   description: Greatly reduce the chance of your ship taking damage in flight.

--- a/data/Ship Handling.yaml
+++ b/data/Ship Handling.yaml
@@ -10,7 +10,9 @@
   time: 2100
   title: Basic Ship Handling
 - availability:
+  - HS
   - NL
+  - Syr
   cost: 28000
   description: Advanced Ship Handling
   level: 5

--- a/data/Ship Technology.yaml
+++ b/data/Ship Technology.yaml
@@ -13,7 +13,9 @@
   time: 1400
   title: Basic Ship Technology
 - availability:
+  - HS
   - Moi
+  - Syr
   cost: 16800
   description: Advanced Ship Technology
   level: 4

--- a/data/Space Navigation.yaml
+++ b/data/Space Navigation.yaml
@@ -34,6 +34,7 @@
 
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 8400
   description: Enables 2 consecutive jumps for small ships (e.g. Private Shuttle). Unlocks higher level Multi-Jump Ship Navigation Courses
@@ -46,6 +47,7 @@
 
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 16800
   description: 'Increased number of consecutive jumps for small and medium ships. Small ship (e.g. Private Shuttle): 3, medium ship (e.g. Razorback): 2'
@@ -58,6 +60,7 @@
 
 - availability:
     - CVS
+    - HS
     - Syr
   description: 'Increased number of consecutive jumps depending on ship size. Small ship: 4, medium ship: 3'
   cost: 28000
@@ -70,6 +73,8 @@
 
 - availability:
     - CVS
+    - HS
+    - Syr
   description: "Increased number of consecutive jumps depending on ship size. Small ship: 9, medium ship: 7, large ship: 4."
   cost: 42000
   level: 6
@@ -80,6 +85,7 @@
 
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 49000
   description: "Enables maximum 9 consecutive jumps for medium ships. Also increases large ship limit to 7 jumps."
@@ -91,6 +97,7 @@
 
 - availability:
     - CVS
+    - HS
     - Syr
   cost: 56000
   description: "Enables maximum 9 consecutive jumps for large ships."

--- a/data/Syndicate Foundation.yaml
+++ b/data/Syndicate Foundation.yaml
@@ -1,0 +1,12 @@
+---
+- availability:
+  - Moi
+  - NL
+  - SoB
+  - Syr
+  - Tau
+  level: 2
+  module: Syndicate Foundation
+  prerequisites:
+  - Introduction to Leadership
+  title: Syndicate Basics

--- a/data/Trade.yaml
+++ b/data/Trade.yaml
@@ -12,7 +12,9 @@
   time: 700
   title: Basic Trading
 
-- availability: [Moi]
+- availability:
+  - HS
+  - Moi
   cost: 8400
   description: Increase your standing as professional trader with expanded marketing and retail strategies. Your certificate will be upgraded, increasing your trade slots by two.
   level: 3
@@ -21,7 +23,9 @@
   time: 1400
   title: Trading Expanded
 
-- availability: [Tau]
+- availability:
+  - HS
+  - Tau
   cost: 16800
   description: Further increase your standing as professional trader with enhanced marchandising and brand tactics. Your certificate will be upgraded, increasing your trade slots by two.
   level: 4
@@ -30,7 +34,9 @@
   time: 2100
   title: Trading Expanded Further
 
-- availability: [SoB]
+- availability:
+  - HS
+  - SoB
   cost: 28000
   description: Delve into the hidden secrets of the vendor gurus, attaining knowledge reserved for the highest retailers across the galaxy. Your certificate will be upgraded, increasing your trade slots by two.
   level: 5
@@ -39,7 +45,9 @@
   time: 2800
   title: Advanced Trading
 
-- availability: [NL]
+- availability:
+  - HS
+  - NL
   cost: 42000
   description: Achieve the true enlightenment of zen marketing and venerable trading. High caliber sales strategies and merchandising tactics are revealed and upgraded your certificate to the highest level, increasing your trade slots by two.
   level: 6


### PR DESCRIPTION
Hi there, and thanks for tauguide.de and all these amazing tools!

I noticed that the availability listed in the course descriptions in Tau Station didn't always match the ones stated here. Today, I compared the data manually for most of the courses, and it seems that the Sirius university is missing here a lot of the time.

There were a number of courses I couldn't check, mostly because I've already taken them, which as you know causes the Tau Station UI to hide the availability. For the record, the ones I didn't check are:

- Advanced Ship Maintenance
- Armor specialization, energy
- Armor specialization, impact
- Basic Navigation Systems
- Basic Ship Handling
- Basic Ship Maintenance
- Basic Ship Technology
- Basic Space Navigation
- Basic Trading
- Close Combat Basics
- Combat
- Combat Utilities 1
- Combat Utilities 2
- Consortium Reputation
- Evasive Tactics Specialist
- First Aid
- Gaule Reputation
- Healthcare Basics
- Introduction to Business
- Introduction to Electronics
- Introduction to Engineering
- Introduction to Leadership
- Introduction to Ship Engineering
- Introduction to Spaceship Operations
- Introduction to the Consortium
- Introduction to the Gaule Protectorate
- Item repair 1
- Item repair 2
- Item repair 3
- Item repair 4
- Medical Stims
- Ranged Combat Basics
- Social Skills
- Special Ops—Critical 1

Additionally, this change adds the Syndicate Basics course, which I think is fairly new.

Hope this helps!